### PR TITLE
Fix URL typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In your emacs config:
 
 Get the `Personal API Access Token` from:
 
-https://yourteam.esa.io/user/token
+https://yourteam.esa.io/user/tokens
 
 Put following to your .emacs:
 


### PR DESCRIPTION
token =>
tokens

---

> アクセストークンは、ユーザの管理画面(https://[team].esa.io/user/token**s**)から発行できます。

( cite: https://docs.esa.io/posts/102 )
