### PR TITLE
🐛 Fix free variable 'json' with Travis CI.

### DIFF
--- a/esa.el
+++ b/esa.el
@@ -336,7 +336,7 @@ Parses the result and displays the list."
                       'repo number
                       'action 'esa-describe-button
                       'face 'default
-                      'esa-json esa))
+                      'esa-jsonesa))
   (insert "\n"))
 
 (defun esa-parse-esa (esa)
@@ -393,7 +393,6 @@ for the esa."
   "Show your esa describe."
   (setq buffer-read-only nil)
   (erase-buffer)
-  (esa-describe-esa-1 json)
   (setq buffer-read-only t)
   (goto-char (point-min)) (re-search-forward "^-\r?\n\n" nil t)
   (setq truncate-lines t)
@@ -417,6 +416,7 @@ for the esa."
   (let ((json (button-get button 'esa-json)))
     (with-current-buffer (get-buffer-create "*esa*")
       (esa-describe-read-mode)
+      (esa-describe-esa-1 json)
       (switch-to-buffer "*esa*"))))
 
 (defun esa-describe-read-only-header ()


### PR DESCRIPTION
There is a warning message that I seen when running `make EMACS=emacs24 check`on the package:

``` sh
emacs -q -batch -f batch-byte-compile esa.el
Warning: reference to free variable `json'
...
```
