### PR TITLE
🐛 esa-request-0 complains about multibytes characters

### DIFF
--- a/esa.el
+++ b/esa.el
@@ -590,7 +590,7 @@ Edit the esa tags."
 (defun esa-request-0 (auth method url callback &optional json-or-params)
   (let* ((json (and (member method '("POST" "PATCH")) json-or-params))
          (params (and (member method '("GET" "DELETE")) json-or-params))
-         (url-request-data (and json (concat (json-encode json) "\n")))
+         (url-request-data (and json (concat (encode-coding-string (json-encode json) 'utf-8) "\n")))
          (url-request-extra-headers
           `(("Authorization" . ,auth)
             ("Content-Type" . "application/json;charset=UTF-8")))


### PR DESCRIPTION
When the json-or-params of the function esa-request-0 contains multibytes characters, the value stored in the variable url-request-data is not properly encoded as a unibyte character string.

This bug occures with emacs 25.2+

It's probably the same bug which occures here:
https://github.com/proofit404/anaconda-mode/issues/189